### PR TITLE
Fix: correct JavaScript syntax in script.js

### DIFF
--- a/script.js
+++ b/script.js
@@ -6,15 +6,15 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const gData = {
         nodes: [
-            [cite_start]{ id: 0, name: 'G.A.J.R.A. Earth', description: 'Stands for "Global Association for Joyful Responsible Abundance on Earth." It is a not-for-profit initiative designed to harness volunteerism and XR technologies to address sustainable development goals and foster global unity. [cite: 1493, 1495, 1496]' },
-            [cite_start]{ id: 1, name: 'Aura of Intelligence', description: 'A tech start-up creating an extended reality (XR) digital twin of a user\'s body and mind, which integrates with generative AI, blockchain, and IoT devices to augment human capabilities. [cite: 1485, 1488, 1489, 1490]' },
-            [cite_start]{ id: 2, name: 'Live Aid 2025/2035', description: 'Large-scale global art and music events marking the 40th and 50th anniversaries of Live Aid, aimed at promoting global unity and collective voting on core values. [cite: 1497, 1502]' },
-            [cite_start]{ id: 3, name: 'Gamify Democracy', description: 'An initiative to make the democratic process more interactive and intellectually stimulating by using gaming principles and generative AI. [cite: 1519, 1520]' },
-            [cite_start]{ id: 4, name: 'ICO & DAO', description: 'An Initial Coin Offering (ICO) and a Decentralized Autonomous Organization (DAO) are planned to democratize investment and governance for the GAJRA Earth ecosystem. [cite: 1467]' },
-            [cite_start]{ id: 5, name: 'Queens Venture Capital', description: 'A series of venture capital firms (500, 10,000, and 50,000 Queens) focused on empowering female entrepreneurship and addressing gender disparity in VC funding globally. [cite: 1529, 1530, 1535, 1540]' },
-            [cite_start]{ id: 6, name: 'Aura Entrepreneurs Co-Living', description: 'A co-living network for entrepreneurs and volunteers to cohabit, collaborate, and foster a community of innovation and social impact. [cite: 1525, 1526]' },
-            [cite_start]{ id: 7, name: 'Aura Smart Pod Hotels', description: 'High-tech capsule hotels equipped with automation, XR, and AI, designed as hubs for rest, productivity, and collaboration for the traveling Aura community. [cite: 1562, 1563, 1564]' },
-            [cite_start]{ id: 8, name: 'Aura Innovation Labs', description: 'Creative spaces within educational institutions to nurture innovation by leveraging Aura of Intelligence technology for learning and research. [cite: 1568, 1569]' }
+            { id: 0, name: 'G.A.J.R.A. Earth', description: 'Stands for "Global Association for Joyful Responsible Abundance on Earth." It is a not-for-profit initiative designed to harness volunteerism and XR technologies to address sustainable development goals and foster global unity. [cite: 1493, 1495, 1496]' },
+            { id: 1, name: 'Aura of Intelligence', description: 'A tech start-up creating an extended reality (XR) digital twin of a user\'s body and mind, which integrates with generative AI, blockchain, and IoT devices to augment human capabilities. [cite: 1485, 1488, 1489, 1490]' },
+            { id: 2, name: 'Live Aid 2025/2035', description: 'Large-scale global art and music events marking the 40th and 50th anniversaries of Live Aid, aimed at promoting global unity and collective voting on core values. [cite: 1497, 1502]' },
+            { id: 3, name: 'Gamify Democracy', description: 'An initiative to make the democratic process more interactive and intellectually stimulating by using gaming principles and generative AI. [cite: 1519, 1520]' },
+            { id: 4, name: 'ICO & DAO', description: 'An Initial Coin Offering (ICO) and a Decentralized Autonomous Organization (DAO) are planned to democratize investment and governance for the GAJRA Earth ecosystem. [cite: 1467]' },
+            { id: 5, name: 'Queens Venture Capital', description: 'A series of venture capital firms (500, 10,000, and 50,000 Queens) focused on empowering female entrepreneurship and addressing gender disparity in VC funding globally. [cite: 1529, 1530, 1535, 1540]' },
+            { id: 6, name: 'Aura Entrepreneurs Co-Living', description: 'A co-living network for entrepreneurs and volunteers to cohabit, collaborate, and foster a community of innovation and social impact. [cite: 1525, 1526]' },
+            { id: 7, name: 'Aura Smart Pod Hotels', description: 'High-tech capsule hotels equipped with automation, XR, and AI, designed as hubs for rest, productivity, and collaboration for the traveling Aura community. [cite: 1562, 1563, 1564]' },
+            { id: 8, name: 'Aura Innovation Labs', description: 'Creative spaces within educational institutions to nurture innovation by leveraging Aura of Intelligence technology for learning and research. [cite: 1568, 1569]' }
         ],
         links: [
             { source: 0, target: 1 }, { source: 0, target: 2 },


### PR DESCRIPTION
The `script.js` file contained invalid `[cite_start]` markers within the `nodes` array, which caused a JavaScript syntax error and prevented the page from rendering.

This commit removes these markers to ensure the JavaScript is parsed and executed correctly.