### PR TITLE
Fix: use https for external script URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
         <button id="close-btn">Close</button>
     </div>
 
-    <script src="//unpkg.com/three"></script>
-    <script src="//unpkg.com/3d-force-graph"></script>
+    <script src="https://unpkg.com/three"></script>
+    <script src="https://unpkg.com/3d-force-graph"></script>
     <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The external scripts from unpkg.com were loaded using protocol-relative URLs (`//unpkg.com/...`). This fails when the `index.html` file is opened directly from the local filesystem (`file://` protocol).

This commit changes the URLs to use `https://` to ensure the scripts can be loaded in all environments.