### PR TITLE
Fix: use absolute asset paths for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>GAJRA Earth Ecosystem</title>
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="/GAJRA-earth/style.css">
 </head>
 <body>
     <div id="3d-graph"></div>
@@ -16,6 +16,6 @@
 
     <script src="https://unpkg.com/three"></script>
     <script src="https://unpkg.com/3d-force-graph"></script>
-    <script src="script.js"></script>
+    <script src="/GAJRA-earth/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The asset URLs for `style.css` and `script.js` were relative, which fails when the site is served from a subdirectory on GitHub Pages (e.g., `/GAJRA-earth/`).

This commit changes the asset paths to be absolute from the site root (e.g., `/GAJRA-earth/style.css`) to ensure they resolve correctly.